### PR TITLE
Footer hidden on specific pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This filament Plugin provides an easy and flexible way to add a customizable foo
     - [Custom logo with link](#custom-logo-with-link)
     - [Add customs links](#links)
     - [Border on top](#border-on-top)
-    - [Hiding from auth pages](#hiding-from-auth-pages)
+    - [Hiding from specific pages](#hiding-from-specific-pages)
 - [Testing](#testing)
 - [Contributing](#contributing)
 -  [Changelog](#changelog)
@@ -275,17 +275,30 @@ use Devonab\FilamentEasyFooter\EasyFooterPlugin;
 ])
 ```
 
-### Hiding from auth pages
-By default, the footer is also showed on the 3 auth pages : login, forgot-password and register. You can hide it by using this configuration :
+### Hiding from specific pages
+By default, the footer is also showed on the 3 auth pages : admin/login, admin/forgot-password and admin/register. You can hide it by using this configuration :
 
 ```php
 use Devonab\FilamentEasyFooter\EasyFooterPlugin;
 
 ->plugins([
     EasyFooterPlugin::make()
-    ->hideFromAuthPages(),
+    ->hiddenFromPagesEnabled(),
 ])
 ```
+
+If you would like to hide the footer on other pages, you can use this configuration :
+```php
+use Devonab\FilamentEasyFooter\EasyFooterPlugin;
+
+->plugins([
+    EasyFooterPlugin::make()
+    ->hiddenFromPagesEnabled()
+    ->hiddenFromPages(['sample-page', 'another-page', 'admin/login', 'admin/forgot-password', 'admin/register']),
+])
+```
+
+Note that anything set in `hiddenFromPages()` will override the default behavior.
 
 
 

--- a/src/EasyFooterPlugin.php
+++ b/src/EasyFooterPlugin.php
@@ -11,7 +11,7 @@ class EasyFooterPlugin implements Plugin
 {
     private const MAX_LINKS = 3;
 
-    private const AUTH_PATHS = ['admin/login', 'admin/register', 'admin/forgot-password'];
+    private array $hiddenPaths = ['admin/login', 'admin/register', 'admin/forgot-password'];
 
     protected bool $githubEnabled = false;
 
@@ -21,7 +21,7 @@ class EasyFooterPlugin implements Plugin
 
     protected bool $showUrl = true;
 
-    protected bool $hideFromAuthPagesEnabled = false;
+    protected bool $hiddenFromPagesEnabled = false;
 
     protected bool $loadTimeEnabled = false;
 
@@ -81,7 +81,7 @@ class EasyFooterPlugin implements Plugin
      */
     public function shouldSkipRendering(): bool
     {
-        return $this->hideFromAuthPagesEnabled && $this->isOnAuthPage();
+        return $this->hiddenFromPagesEnabled && $this->isOnHiddenPage();
     }
 
     /**
@@ -111,9 +111,9 @@ class EasyFooterPlugin implements Plugin
     /**
      * Check if the current page is an auth page
      */
-    protected function isOnAuthPage(): bool
+    protected function isOnHiddenPage(): bool
     {
-        return in_array(request()->path(), self::AUTH_PATHS, true);
+        return in_array(request()->path(), $this->hiddenPaths, true);
     }
 
     /**
@@ -137,13 +137,27 @@ class EasyFooterPlugin implements Plugin
     }
 
     /**
-     * Configure whether to hide the footer from auth pages
+     * Configure whether to hide the footer from specific pages
      *
      * @return static EasyFooterPlugin
      */
-    public function hideFromAuthPages(bool $enabled = true): static
+    public function hiddenFromPagesEnabled(bool $enabled = true): static
     {
-        $this->hideFromAuthPagesEnabled = $enabled;
+        $this->hiddenFromPagesEnabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Hide from these specific pages
+     *
+     * @param  array  $pages  Array of pages to hide the footer on
+     * 
+     * @return static EasyFooterPlugin
+     */
+    public function hiddenFromPages(array $pages): static
+    {
+        $this->hiddenPaths = $pages;
 
         return $this;
     }

--- a/tests/Feature/FilamentPluginTest.php
+++ b/tests/Feature/FilamentPluginTest.php
@@ -8,13 +8,36 @@ it('has correct plugin ID')
     ->expect(fn () => EasyFooterPlugin::make()->getId())
     ->toBe('filament-easy-footer');
 
-it('skips rendering on auth pages', function () {
+it('shows footer by default', function () {
     $request = Mockery::mock(Request::class)->makePartial();
-    $request->shouldReceive('path')->andReturn('admin/login');
+    $request->shouldReceive('path')->andReturn('admin/dashboard');
+    app()->instance('request', $request);
+
+    $plugin = EasyFooterPlugin::make();
+
+    expect($plugin->shouldSkipRendering())->toBeFalse();
+});
+
+it('shows footer on non-configured page', function () {
+    $request = Mockery::mock(Request::class)->makePartial();
+    $request->shouldReceive('path')->andReturn('admin/dashboard');
     app()->instance('request', $request);
 
     $plugin = EasyFooterPlugin::make()
-        ->hideFromAuthPages();
+        ->hiddenFromPagesEnabled()
+        ->hiddenFromPages(['admin/users', 'admin/login']);
+
+    expect($plugin->shouldSkipRendering())->toBeFalse();
+});
+
+it('hides footer on configured page', function () {
+    $request = Mockery::mock(Request::class)->makePartial();
+    $request->shouldReceive('path')->andReturn('admin/dashboard');
+    app()->instance('request', $request);
+
+    $plugin = EasyFooterPlugin::make()
+        ->hiddenFromPagesEnabled()
+        ->hiddenFromPages(['admin/dashboard', 'admin/login']);
 
     expect($plugin->shouldSkipRendering())->toBeTrue();
 });


### PR DESCRIPTION
The plugin has functionality to "hide on auth pages", however, the paths set in the auth constant are not always the auth pages. 
This PR allows the user to set their own array of pages to ignore the footer on (not just auth pages). See readme for methods. 