### PR TITLE
fix: guard stubs publish against missing directory on Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /docs                   export-ignore
 /images                 export-ignore
 /tests                  export-ignore
+/stubs                  export-ignore
 /package.json           export-ignore
 /phpstan-baseline.neon  export-ignore
 /phpstan.neon.dist      export-ignore

--- a/src/EasyFooterServiceProvider.php
+++ b/src/EasyFooterServiceProvider.php
@@ -63,10 +63,12 @@ class EasyFooterServiceProvider extends PackageServiceProvider
         );
 
         if (app()->runningInConsole()) {
-            foreach (app(Filesystem::class)->files(__DIR__ . '/../stubs/') as $file) {
-                $this->publishes([
-                    $file->getRealPath() => base_path("stubs/filament-easy-footer/{$file->getFilename()}"),
-                ], 'filament-easy-footer-stubs');
+            if (is_dir(__DIR__ . '/../stubs/')) {
+                foreach (app(Filesystem::class)->files(__DIR__ . '/../stubs/') as $file) {
+                    $this->publishes([
+                        $file->getRealPath() => base_path("stubs/filament-easy-footer/{$file->getFilename()}"),
+                    ], 'filament-easy-footer-stubs');
+                }
             }
         }
 


### PR DESCRIPTION
Fixing issue #29 